### PR TITLE
[PATCH] Add support for listing Tor/onion and i2p invidious instances.

### DIFF
--- a/src/index.pug
+++ b/src/index.pug
@@ -37,6 +37,7 @@ html(lang="en")
 			table
 				thead
 					tr
+						th(scope="col") Type
 						th(scope="col") Region
 						th(scope="col") Domain
 						th(scope="col") Health

--- a/src/main.js
+++ b/src/main.js
@@ -56,15 +56,27 @@
 				healthKnown
 			}
 		}).filter(entry => {
-			return entry.details.type === "https" && entry.health > 0
+			return entry.health > 0
 		}).sort((a, b) => {
 			return b.health - a.health
 		}).forEach(entry => {
-			let target = entry.details.uri.replace(/\/*$/, "") + destinationPath
+			let address = entry.details.uri.replace(/\/*$/, "")
+			let target = address + destinationPath
 			const healthUnknown = entry.healthKnown ? "" : "health-unknown "
+			let type = "default"
+			switch(address.substr(address.lastIndexOf('.')+1))
+			{
+				case "onion":
+					type = "onion"
+					break
+				case "i2p":
+					type = "i2p"
+					break
+			}
 			const health = entry.healthKnown ? entry.health.toFixed(0) : "(unknown)"
 			q("#instances-tbody").appendChild(
 				createElement("tr", {}, [
+					createElement("td", {className: "column-center", textContent: type}),
 					createElement("td", {textContent: `${entry.details.flag} ${entry.details.region}`}),
 					createElement("td", {textContent: entry.name}),
 					createElement("td", {className: "column-center "+healthUnknown, textContent: health}),


### PR DESCRIPTION
Hello! I made a few changes to the redirector to permit Tor/onion and I2P links to be listed as part of the same table. Ultimately, this was up to everyone's Feng-Shui; whether there should be a separate table for darknet, whether the table would be after the clearnet one, whether it should be to the right, etc, but I decided that darknet links are just as important and should just be part of the entire corpus of links.

There is one problem, but more like a debate. All darknet links, that includes both Tor/onion and I2P appear with health being "unknown" and I am not sure whether this is from the API itself at ``api.invidious.io`` or whether people simply hide their ``/stats`` for darknet addresses. In any case, I do not see why health reports could not be generated for darknet invidious instances as well and at the very least it would not be deanonimizing to the end-user (and I doubt it would to the server either). That being said, and for further work, either the health check ``return entry.health > 0`` can be removed thereby making invidious list everything or either ``api.invidious.io`` or the individual instances should enable the ``/stats`` link to check for health. There is not reason why Tor/onion or I2P services could not be ranked along the rest and it's just the transport that differs.

As a demo, please see the following website:

- https://invidious.grimore.org/

that shows the result of this commit.

One more comment is that ``api.invidious.io`` reports all I2P address names with the "http" prefix whereas both onion and clearnet addresses have the starting "http", respectively "https" prefix stripped from the returned ``name`` parameter. Not sure why and it is ultimately irrelevant to this pull request but just mentioning it.

Please apply if useful.