### PR TITLE
Workaround the fact that uptimerobot doesn't return the dailyRatio anymore

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -52,7 +52,7 @@
 			return {
 				name: entry[0],
 				details: entry[1],
-				health: +(healthKnown ? entry[1].monitor.dailyRatios[0].ratio : 95),
+				health: 100,
 				healthKnown
 			}
 		}).filter(entry => {


### PR DESCRIPTION
Really dirty workaround the fact that uptimerobot doesn't return the dailyRatio anymore, it's temporary and basically just set the value to 100 instead of looking for it.