### PR TITLE
Update to use the new layout from api

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -52,7 +52,7 @@
 			return {
 				name: entry[0],
 				details: entry[1],
-				health: +(healthKnown ? entry[1].monitor["30dRatio"].ratio : 95),
+				health: +(healthKnown ? entry[1].monitor.uptime : 95),
 				healthKnown
 			}
 		}).filter(entry => {


### PR DESCRIPTION
Update to use the new layout from api after the migration to updown.

Tested and working perfectly.

Changing the API might not have been a good idea though... even if "ratio" wasn't a good name for the "uptime value" I'm expecting that other projects might have depended on it (though I guess we can force them to update to "uptime"... even if doing it without warning isn't ideal)